### PR TITLE
Make get_ignore_regex() look in a default location for the ignore file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Configure errbit with environment variables:
   implementation can solve different problems when communicating from private
   networks with HTTP proxies. Current implementations are: ``requests``, ``urllib``,
   ``urllib2``.
-- ``ERRBIT_IGNORE`` - path to ignore file.
+- ``ERRBIT_IGNORE`` - path to ignore file (default: ~/.errbit/errbit_ignore.json)
 
 Ignore file
 -----------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make get_ignore_regex() look in a default location for the ignore file.
+  [lgraf]
 
 
 1.1.5 (2014-08-11)

--- a/errbit/client.py
+++ b/errbit/client.py
@@ -65,8 +65,11 @@ class Client(object):
                 'url': 'https://github.com/4teamwork/errbit-python'}
 
     def get_ignore_regex(self):
-        cfg_path = os.environ.get('ERRBIT_IGNORE')
-        if not cfg_path:
+        cfg_path = os.environ.get(
+            'ERRBIT_IGNORE',
+            os.path.expanduser('~/.errbit/errbit_ignore.json'))
+
+        if not os.path.isfile(cfg_path):
             return []
 
         try:

--- a/errbit/client.py
+++ b/errbit/client.py
@@ -28,7 +28,8 @@ class Client(object):
             logging.error('ERRBIT_URL not configured as environment variable.')
 
         if not self.get_api_key():
-            logging.error('ERRBIT_API_KEY not configured as environment variable.')
+            logging.error('ERRBIT_API_KEY not configured as environment '
+                          'variable.')
 
         if self.is_ignored(exc_info):
             return
@@ -39,15 +40,16 @@ class Client(object):
                                         environment=self.get_environment())
 
         http_client = self.http_client()
-        req = ThreadedRequest(self.get_errbit_url(), xml, http_client=http_client)
+        req = ThreadedRequest(
+            self.get_errbit_url(), xml, http_client=http_client)
         req.start()
 
     def http_client(self):
         client_name = os.environ.get('ERRBIT_HTTP_CLIENT', 'requests')
         if client_name not in httpclients.HTTP_CLIENTS:
-            raise Exception(('ERRBIT_HTTP_CLIENT: "%s" is no valid client name. '
-                             'Valid clients are: %s') % (
-                    client_name, str(httpclients.HTTP_CLIENTS.keys())))
+            raise Exception(('ERRBIT_HTTP_CLIENT: "%s" is no valid client '
+                             'name. Valid clients are: %s') % (
+                client_name, str(httpclients.HTTP_CLIENTS.keys())))
 
         return httpclients.HTTP_CLIENTS.get(client_name)()
 
@@ -71,10 +73,12 @@ class Client(object):
             cfg = json.load(open(cfg_path, 'r'))
             return cfg['exception_msg']
         except Exception, exc:
-            raise ErrbitInvalidConfigFileException(': '.join((exc.__class__.__name__, str(exc))))
+            raise ErrbitInvalidConfigFileException(
+                ': '.join((exc.__class__.__name__, str(exc))))
 
     def is_ignored(self, exc_info):
-        exc_message = traceback.format_exception_only(exc_info[0], exc_info[1])[-1].strip('\n')
+        exc_message = traceback.format_exception_only(
+            exc_info[0], exc_info[1])[-1].strip('\n')
 
         if exc_info[0] != ErrbitInvalidConfigFileException:
             try:


### PR DESCRIPTION
This makes deploying ignore patterns easier, because we can simply place an ignore file at `~/.errbit/errbit_ignore.json` without the need for explicitly setting an environment variable and running buildout again. 