### PR TITLE
Log exceptions while handling exceptions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.6 (unreleased)
 ------------------
 
+- Post "unknown" app version when ERRBIT_PACKAGE is invalid.
+  [jone]
+
 - Log errors happening while handling errors.
   [jone]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.6 (unreleased)
 ------------------
 
+- Log errors happening while handling errors.
+  [jone]
+
 - Make get_ignore_regex() look in a default location for the ignore file.
   [lgraf]
 

--- a/errbit/client.py
+++ b/errbit/client.py
@@ -1,6 +1,7 @@
 from errbit import httpclients
 from errbit import xmlgenerator
 from errbit.request import ThreadedRequest
+from pkg_resources import DistributionNotFound
 import json
 import logging
 import os
@@ -14,7 +15,10 @@ LOG = logging.getLogger('errbit')
 
 
 def get_version(package):
-    return pkg_resources.require(package)[0].version
+    try:
+        return pkg_resources.require(package)[0].version
+    except DistributionNotFound:
+        return 'unkown'
 
 
 class ErrbitInvalidConfigFileException(Exception):

--- a/errbit/plone/loghandler.py
+++ b/errbit/plone/loghandler.py
@@ -1,5 +1,6 @@
 from errbit.client import Client
 from errbit.plone.cleanup import cleanup_request_info
+from errbit.utils import logging_exceptions
 from zope.component.hooks import getSite
 import logging
 import sys
@@ -17,6 +18,10 @@ class ErrbitLoggingHandler(logging.Handler):
         if exc_info[0] is None:
             return
 
+        if getattr(exc_info[1], '_errbit_do_not_report', None):
+            # This is an exception while emitting another exception.
+            return
+
         # This is a logging handler, not an exception handler.
         # By storing the last consumed exception we can make the handler
         # only report on new exceptions.
@@ -30,6 +35,7 @@ class ErrbitLoggingHandler(logging.Handler):
         except:
             pass
 
+    @logging_exceptions
     def notify_errbit(self, exc_info):
         client = Client()
         request_info = self.get_request_info()

--- a/errbit/tests/test_client.py
+++ b/errbit/tests/test_client.py
@@ -1,5 +1,6 @@
 from errbit import httpclients
 from errbit.client import Client
+from errbit.client import get_version
 from mocker import MockerTestCase
 import os
 import pkg_resources
@@ -41,6 +42,10 @@ class TestClient(MockerTestCase):
         for key in filter(lambda key: key.startswith('ERRBIT_'),
                           os.environ.keys()):
             del os.environ[key]
+
+    def test_get_version(self):
+        self.assertEqual(ERRBIT_VERSION, get_version('errbit'))
+        self.assertEqual('unkown', get_version('errbitly'))
 
     def test_set_api_key_with_environment_variables(self):
         os.environ['ERRBIT_API_KEY'] = 'abcd1234'

--- a/errbit/tests/test_utils.py
+++ b/errbit/tests/test_utils.py
@@ -1,0 +1,38 @@
+from errbit.utils import logging_exceptions
+from StringIO import StringIO
+from unittest2 import TestCase
+import logging
+
+
+
+class TestLoggingErrors(TestCase):
+
+    def setUp(self):
+        self.logstream = StringIO()
+        self.handler = logging.StreamHandler(self.logstream)
+        logging.root.addHandler(self.handler)
+        self.original_log_level = logging.root.level
+        logging.root.setLevel(logging.ERROR)
+
+    def tearDown(self):
+        logging.root.removeHandler(self.handler)
+        logging.root.level = self.original_log_level
+
+    def get_log(self):
+        self.handler.flush()
+        return self.logstream.getvalue()
+
+    def test_logs_exceptions(self):
+        @logging_exceptions
+        def foo():
+            raise KeyError('bar')
+
+        with self.assertRaises(KeyError) as cm:
+            foo()
+        self.assertTrue(cm.exception._errbit_do_not_report)
+
+        log_lines = self.get_log().strip().splitlines()
+        self.assertEquals('exception while trying to report other exception:',
+                          log_lines[0])
+        self.assertEquals('KeyError: \'bar\'',
+                          log_lines[-1])

--- a/errbit/utils.py
+++ b/errbit/utils.py
@@ -1,0 +1,17 @@
+from decorator import decorator
+import logging
+
+LOG = logging.getLogger('errbit')
+
+
+@decorator
+def logging_exceptions(func, *args, **kwargs):
+    """This decorator can be used in code trying to report an exception with errbit.
+    It re-loggs exceptions happened during rendering an errbit exception.
+    """
+    try:
+        return func(*args, **kwargs)
+    except Exception, exc:
+        exc._errbit_do_not_report = True
+        LOG.exception('exception while trying to report other exception:')
+        raise

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,10 @@ setup(name='errbit',
       zip_safe=False,
 
       install_requires=[
+        'decorator',
+        'requests',
         'setuptools',
         'xmlbuilder',
-        'requests',
         ],
 
       tests_require=tests_require,


### PR DESCRIPTION
### 1. Nested exceptions
When exceptions happen in an exception handler, nothing was logged.
Exceptions our now logged (and not reported to errbit) when happening while handling another exception.

### 2. Invalid ERRBIT_PACKAGE
When the value of `ERRBIT_PACKAGE` is not set to an available distribution, we report `unkown` as app version to errbit.

Fixes #3 
/ @senny @buchi 