### PR TITLE
Fix bug when trying to log a cleanup error.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug when trying to log a cleanup error.
+  [jone]
 
 
 1.3.0 (2015-03-02)

--- a/errbit/ploneintegration/cleanup.py
+++ b/errbit/ploneintegration/cleanup.py
@@ -23,8 +23,8 @@ def cleanup_request_info(request):
         try:
             request = cleanup(request)
         except Exception, exc:
-            logging.DEBUG('Failed to apply cleanup (%s): %s' % (
-                    str(cleanup), str(exc)))
+            LOG.warning('Failed to apply cleanup "%s", got %s: %s' % (
+                str(cleanup), type(exc).__name__, str(exc)))
 
     return request
 
@@ -42,6 +42,7 @@ def filter_values(data, key_expression):
             new_data[key] = value
 
     return new_data
+
 
 @cleanup
 def filter_password_from_params(request):


### PR DESCRIPTION
`logging.DEBUG` is a log level and is not callable, changed to `LOG.warning`:
- We want to log on WARNING level so that it appears in logs.
- We dont want to log it on ERROR level, since this would trigger
  errbit and we'd have a loop.
- Add exception type name to the log message.